### PR TITLE
fix: Add Helm ownership metadata to ExternalSecret hooks

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: common
 description: A Helm chart for deploying common apps to Kubernetes
 type: application
-version: 1.2.9
-appVersion: "1.2.9"
+version: 1.3.0
+appVersion: "1.3.0"
 icon: https://cncf-branding.netlify.app/img/projects/helm/horizontal/color/helm-horizontal-color.png

--- a/charts/common/templates/externalSecret.yaml
+++ b/charts/common/templates/externalSecret.yaml
@@ -1,4 +1,5 @@
 {{- $fullName := include "common.fullname" . -}}
+{{- $root := . -}}
 {{ $externalSecrets := default dict .Values.externalSecrets }}
 {{- range $k, $v := .Values.env }}
 {{- include "common.validateEnvType" (dict "type" $v.type "name" $k) }}
@@ -8,12 +9,17 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: "{{ $fullName }}-{{ $v.name }}"
+  labels:
+    {{- include "common.labels" $root | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade,pre-delete
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "meta.helm.sh/release-name": {{ $root.Release.Name }}
+    "meta.helm.sh/release-namespace": {{ $root.Release.Namespace }}
 spec:
   refreshInterval: 1m
+  deletionPolicy: Delete
   secretStoreRef:
     kind: ClusterSecretStore
     name: {{ if eq $v.type "secretsManager" }}{{ $externalSecrets.secretsManagerClusterSecretStoreName | default (printf "%s-secrets-manager" $externalSecrets.clusterSecretStoreName) }}{{ else }}{{ $externalSecrets.clusterSecretStoreName }}{{ end }}


### PR DESCRIPTION
## Problem Solved

  Fixes the error encountered with `bitovi/github-actions-deploy-eks-helm`:
  Error: Unable to continue with install: ExternalSecret "name" in namespace "ns" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key
  "app.kubernetes.io/managed-by": must be set to "Helm"

  ## Impact

  - ExternalSecret resources can now be properly adopted by Helm during upgrades
  - Secrets are automatically cleaned up on `helm uninstall`
  - Hook resources include proper Helm tracking metadata
  - No breaking changes to existing functionality