### PR TITLE
fix(common): manage ExternalSecrets through Helm lifecycle

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -1,0 +1,26 @@
+name: Test Charts
+
+on:
+  pull_request:
+    paths:
+      - "charts/**"
+      - ".github/workflows/helm-test.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Lint common chart
+        run: helm lint charts/common --values charts/common/test-values.yaml
+
+      - name: Test ExternalSecret lifecycle rendering
+        run: charts/common/tests/external-secret-lifecycle.sh

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -14,10 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        with:
+          version: v3.16.2
 
       - name: Lint common chart
         run: helm lint charts/common --values charts/common/test-values.yaml

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: common
 description: A Helm chart for deploying common apps to Kubernetes
 type: application
-version: 1.2.9
-appVersion: "1.2.9"
+version: 1.3.0
+appVersion: "1.3.0"
 icon: https://cncf-branding.netlify.app/img/projects/helm/horizontal/color/helm-horizontal-color.png

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -4,4 +4,5 @@
 
 ```bash
 helm lint charts/common --values charts/common/test-values.yaml
+charts/common/tests/external-secret-lifecycle.sh
 ```

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -44,9 +44,12 @@ ownership check**; deletion can interrupt secret reconciliation.
    ```
 
 4. After that upgrade succeeds, Helm tracks the ExternalSecrets. Retained names
-   update in place; a later upgrade that renames or removes an entry prunes the
-   old ExternalSecret. The effect on the Kubernetes `Secret` managed by External
-   Secrets Operator remains subject to that ExternalSecret's deletion policy.
+   update in place without disrupting their generated Secrets. A later upgrade
+   that renames or removes an entry prunes the old ExternalSecret. With the
+   default `creationPolicy: Owner`, Kubernetes then removes its generated Secret
+   through owner garbage collection. `deletionPolicy: Retain` applies when the
+   provider value disappears; it does not preserve a Secret when its
+   ExternalSecret is deleted.
 
 ## Testing
 

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -1,8 +1,59 @@
 # common Helm Chart
 
+## Upgrading to 1.3.0
+
+Versions before 1.3.0 created `ExternalSecret` objects as Helm hooks, so Helm did
+not track them as ordinary release resources. Adopt the live objects before the
+first 1.3.0 upgrade. **Do not delete live ExternalSecrets to work around Helm's
+ownership check**; deletion can interrupt secret reconciliation.
+
+1. Keep all ExternalSecret names unchanged for the adoption upgrade and collect
+   the exact live names produced by the existing release values.
+2. For every ExternalSecret created by the release, apply Helm's standard
+   ownership metadata and remove the legacy hook annotations:
+
+   ```bash
+   release=my-release
+   namespace=my-namespace
+   external_secret_names=(my-release-common-first my-release-common-second)
+
+   for name in "${external_secret_names[@]}"; do
+     kubectl --namespace "$namespace" label externalsecret "$name" \
+       app.kubernetes.io/managed-by=Helm \
+       --overwrite
+     kubectl --namespace "$namespace" annotate externalsecret "$name" \
+       meta.helm.sh/release-name="$release" \
+       meta.helm.sh/release-namespace="$namespace" \
+       helm.sh/hook- \
+       helm.sh/hook-weight- \
+       helm.sh/hook-delete-policy- \
+       --overwrite
+   done
+   ```
+
+3. Upgrade to 1.3.0 with those names still unchanged:
+
+   ```bash
+   chart_ref=path-or-repository/common
+   values_file=path/to/release-values.yaml
+
+   helm upgrade "$release" "$chart_ref" \
+     --namespace "$namespace" \
+     --version 1.3.0 \
+     --values "$values_file"
+   ```
+
+4. After that upgrade succeeds, Helm tracks the ExternalSecrets. Retained names
+   update in place; a later upgrade that renames or removes an entry prunes the
+   old ExternalSecret. The effect on the Kubernetes `Secret` managed by External
+   Secrets Operator remains subject to that ExternalSecret's deletion policy.
+
 ## Testing
 
 ```bash
 helm lint charts/common --values charts/common/test-values.yaml
 charts/common/tests/external-secret-lifecycle.sh
 ```
+
+The lifecycle script is a Helm render-contract test. It does not perform an
+upgrade against a Kubernetes cluster.

--- a/charts/common/templates/externalSecret.yaml
+++ b/charts/common/templates/externalSecret.yaml
@@ -8,10 +8,6 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: "{{ $fullName }}-{{ $v.name }}"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   refreshInterval: 1m
   secretStoreRef:

--- a/charts/common/tests/external-secret-lifecycle.sh
+++ b/charts/common/tests/external-secret-lifecycle.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+chart_dir="$(cd -- "$script_dir/.." && pwd)"
+values_file="$chart_dir/test-values.yaml"
+
+rendered_with_secret="$(helm template lifecycle "$chart_dir" --values "$values_file")"
+external_secret="$(
+  printf '%s\n' "$rendered_with_secret" |
+    awk 'BEGIN { RS = "---" } /kind: ExternalSecret/ { print }'
+)"
+
+if [[ -z "$external_secret" ]]; then
+  echo "expected an ExternalSecret in the rendered manifest" >&2
+  exit 1
+fi
+
+if grep -q 'helm\.sh/hook' <<<"$external_secret"; then
+  echo "ExternalSecret must be an ordinary Helm-managed resource, not a hook" >&2
+  exit 1
+fi
+
+rendered_without_secret="$(
+  helm template lifecycle "$chart_dir" \
+    --is-upgrade \
+    --values "$values_file" \
+    --set-string env.DB_USER_PASSWORD.type=kv \
+    --set-string env.DB_USER_PASSWORD.value=removed
+)"
+
+if grep -q '^kind: ExternalSecret$' <<<"$rendered_without_secret"; then
+  echo "ExternalSecret remained in the upgrade manifest after its secret-backed env entry was removed" >&2
+  exit 1
+fi
+
+echo "ExternalSecret lifecycle rendering passed"

--- a/charts/common/tests/external-secret-lifecycle.sh
+++ b/charts/common/tests/external-secret-lifecycle.sh
@@ -4,35 +4,106 @@ set -euo pipefail
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 chart_dir="$(cd -- "$script_dir/.." && pwd)"
-values_file="$chart_dir/test-values.yaml"
+fixtures_dir="$script_dir/fixtures"
 
-rendered_with_secret="$(helm template lifecycle "$chart_dir" --values "$values_file")"
-external_secret="$(
-  printf '%s\n' "$rendered_with_secret" |
-    awk 'BEGIN { RS = "---" } /kind: ExternalSecret/ { print }'
-)"
+render_fixture() {
+  helm template lifecycle "$chart_dir" --is-upgrade --values "$fixtures_dir/$1"
+}
 
-if [[ -z "$external_secret" ]]; then
-  echo "expected an ExternalSecret in the rendered manifest" >&2
-  exit 1
-fi
+resource_document() {
+  local manifest="$1"
+  local resource_name="$2"
 
-if grep -q 'helm\.sh/hook' <<<"$external_secret"; then
-  echo "ExternalSecret must be an ordinary Helm-managed resource, not a hook" >&2
-  exit 1
-fi
+  printf '%s\n' "$manifest" |
+    awk -v name="  name: \"$resource_name\"" \
+      'BEGIN { RS = "---" } /kind: ExternalSecret/ && index($0, name) { print }'
+}
 
-rendered_without_secret="$(
-  helm template lifecycle "$chart_dir" \
-    --is-upgrade \
-    --values "$values_file" \
-    --set-string env.DB_USER_PASSWORD.type=kv \
-    --set-string env.DB_USER_PASSWORD.value=removed
-)"
+assert_resource_count() {
+  local manifest="$1"
+  local expected="$2"
+  local actual
 
-if grep -q '^kind: ExternalSecret$' <<<"$rendered_without_secret"; then
-  echo "ExternalSecret remained in the upgrade manifest after its secret-backed env entry was removed" >&2
-  exit 1
-fi
+  actual="$(grep -c '^kind: ExternalSecret$' <<<"$manifest" || true)"
+  if [[ "$actual" -ne "$expected" ]]; then
+    echo "expected $expected ExternalSecrets, rendered $actual" >&2
+    exit 1
+  fi
+}
 
-echo "ExternalSecret lifecycle rendering passed"
+assert_present() {
+  local manifest="$1"
+  local resource_name="$2"
+
+  if [[ -z "$(resource_document "$manifest" "$resource_name")" ]]; then
+    echo "expected ExternalSecret $resource_name" >&2
+    exit 1
+  fi
+}
+
+assert_absent() {
+  local manifest="$1"
+  local resource_name="$2"
+
+  if [[ -n "$(resource_document "$manifest" "$resource_name")" ]]; then
+    echo "did not expect ExternalSecret $resource_name" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  local document="$1"
+  local expected="$2"
+
+  if ! grep -Fq -- "$expected" <<<"$document"; then
+    echo "expected ExternalSecret document to contain: $expected" >&2
+    exit 1
+  fi
+}
+
+assert_no_hooks() {
+  local manifest="$1"
+  local external_secrets
+
+  external_secrets="$(
+    printf '%s\n' "$manifest" |
+      awk 'BEGIN { RS = "---" } /kind: ExternalSecret/ { print }'
+  )"
+  if grep -q 'helm\.sh/hook' <<<"$external_secrets"; then
+    echo "ExternalSecrets must be ordinary Helm-managed resources, not hooks" >&2
+    exit 1
+  fi
+}
+
+initial="$(render_fixture external-secrets-initial.yaml)"
+assert_resource_count "$initial" 2
+assert_no_hooks "$initial"
+assert_present "$initial" lifecycle-common-parameter
+assert_present "$initial" lifecycle-common-secret
+assert_contains "$(resource_document "$initial" lifecycle-common-parameter)" "name: parameter-store"
+assert_contains "$(resource_document "$initial" lifecycle-common-parameter)" "key: /initial/parameter"
+assert_contains "$(resource_document "$initial" lifecycle-common-secret)" "name: secrets-manager"
+assert_contains "$(resource_document "$initial" lifecycle-common-secret)" "key: initial/secret"
+
+retained="$(render_fixture external-secrets-retained.yaml)"
+assert_resource_count "$retained" 2
+assert_no_hooks "$retained"
+assert_present "$retained" lifecycle-common-parameter
+assert_present "$retained" lifecycle-common-secret
+assert_contains "$(resource_document "$retained" lifecycle-common-parameter)" "key: /updated/parameter"
+assert_contains "$(resource_document "$retained" lifecycle-common-secret)" "key: updated/secret"
+
+renamed="$(render_fixture external-secrets-renamed.yaml)"
+assert_resource_count "$renamed" 2
+assert_no_hooks "$renamed"
+assert_absent "$renamed" lifecycle-common-parameter
+assert_present "$renamed" lifecycle-common-parameter-renamed
+assert_present "$renamed" lifecycle-common-secret
+
+removed="$(render_fixture external-secrets-removed.yaml)"
+assert_resource_count "$removed" 1
+assert_no_hooks "$removed"
+assert_present "$removed" lifecycle-common-parameter-renamed
+assert_absent "$removed" lifecycle-common-secret
+
+echo "ExternalSecret render contract passed"

--- a/charts/common/tests/fixtures/external-secrets-initial.yaml
+++ b/charts/common/tests/fixtures/external-secrets-initial.yaml
@@ -1,0 +1,16 @@
+service:
+  port: 80
+
+externalSecrets:
+  clusterSecretStoreName: parameter-store
+  secretsManagerClusterSecretStoreName: secrets-manager
+
+env:
+  PARAMETER:
+    type: parameterStore
+    name: parameter
+    parameter_name: /initial/parameter
+  SECRET:
+    type: secretsManager
+    name: secret
+    secret_name: initial/secret

--- a/charts/common/tests/fixtures/external-secrets-removed.yaml
+++ b/charts/common/tests/fixtures/external-secrets-removed.yaml
@@ -1,0 +1,11 @@
+service:
+  port: 80
+
+externalSecrets:
+  clusterSecretStoreName: parameter-store
+
+env:
+  PARAMETER:
+    type: parameterStore
+    name: parameter-renamed
+    parameter_name: /updated/parameter

--- a/charts/common/tests/fixtures/external-secrets-renamed.yaml
+++ b/charts/common/tests/fixtures/external-secrets-renamed.yaml
@@ -1,0 +1,16 @@
+service:
+  port: 80
+
+externalSecrets:
+  clusterSecretStoreName: parameter-store
+  secretsManagerClusterSecretStoreName: secrets-manager
+
+env:
+  PARAMETER:
+    type: parameterStore
+    name: parameter-renamed
+    parameter_name: /updated/parameter
+  SECRET:
+    type: secretsManager
+    name: secret
+    secret_name: updated/secret

--- a/charts/common/tests/fixtures/external-secrets-retained.yaml
+++ b/charts/common/tests/fixtures/external-secrets-retained.yaml
@@ -1,0 +1,16 @@
+service:
+  port: 80
+
+externalSecrets:
+  clusterSecretStoreName: parameter-store
+  secretsManagerClusterSecretStoreName: secrets-manager
+
+env:
+  PARAMETER:
+    type: parameterStore
+    name: parameter
+    parameter_name: /updated/parameter
+  SECRET:
+    type: secretsManager
+    name: secret
+    secret_name: updated/secret


### PR DESCRIPTION
## What this fixes

The common chart created every ExternalSecret as a Helm hook. Helm does not own hook resources after they run, so removed settings and retired releases left their ExternalSecrets behind indefinitely. This is how production Pylon accumulated 68 objects while using only eight.

This release makes ExternalSecrets ordinary Helm-managed resources. Retained entries update in place; removed entries and uninstalled releases are cleaned up normally.

## Upgrade note

This is `common` 1.3.0 because existing hook-created ExternalSecrets need a one-time ownership adoption before upgrading. The README includes the exact Helm 3.16 procedure. Do not delete live ExternalSecrets during migration because their generated Secrets are owner-managed.

## Verification

- `helm lint charts/common --values charts/common/test-values.yaml`
- `charts/common/tests/external-secret-lifecycle.sh`
- Render cases cover Parameter Store, Secrets Manager, retained names, rename, and removal.
- Independent hostile review passed after the migration and ESO ownership wording were corrected.

Linear: BAP-1027
